### PR TITLE
fix: remove mode field from IL-Core-LocationNursingUnit profile

### DIFF
--- a/ILCore/input/fsh/Profiles/IL-Core-LocationNursingUnit.fsh
+++ b/ILCore/input/fsh/Profiles/IL-Core-LocationNursingUnit.fsh
@@ -22,4 +22,3 @@ Description: "Israel Core constraints for nursing unit locations"
 * type.coding[hospital-unit].display = "Hospital unit" (exactly)
 * type.coding ^short = "Hospital nursing unit"
 * type.coding ^definition = "Fixed to the IL Core hospital nursing unit code."
-* mode = #kind


### PR DESCRIPTION
This pull request makes a minor update to the `IL-Core-LocationNursingUnit.fsh` profile, specifically removing the constraint that required the `mode` field to be set to `#kind`. This change may allow for more flexibility in how nursing unit locations are represented.
resolves #134 