### PR TITLE
Update IL Core diagnosis role terminology

### DIFF
--- a/ILCore/input/fsh/Aliases-fsh.fsh
+++ b/ILCore/input/fsh/Aliases-fsh.fsh
@@ -364,6 +364,6 @@ Alias: $vs-il-hdp-information-buckets           = http://fhir.health.gov.il/Valu
 Alias: $vs-resource-role-context                = http://fhir.health.gov.il/ValueSet/resource-role-context
 // ConceptMaps
 Alias: $concept-religion =              http://fhir.health.gov.il/ConceptMap/il-core-religions
+Alias: $concept-il-core-diagnosis-role-to-snomed = http://fhir.health.gov.il/ConceptMap/il-core-diagnosis-role-to-snomed
 //mimetypes
 Alias: $mime-types =  urn:ietf:bcp:13
-

--- a/ILCore/input/fsh/ConceptMaps/ConceptMap-il-core-diagnosis-role-to-snomed.fsh
+++ b/ILCore/input/fsh/ConceptMaps/ConceptMap-il-core-diagnosis-role-to-snomed.fsh
@@ -1,0 +1,25 @@
+Instance: ILCoreDiagnosisRoleToSnomed
+InstanceOf: ConceptMap
+Usage: #definition
+Title: "IL Core Diagnosis Role to SNOMED CT"
+Description: "Mapping from deprecated IL Core diagnosis role codes to SNOMED CT diagnosis role qualifier values."
+* url = $concept-il-core-diagnosis-role-to-snomed
+* version = "0.21.0"
+* name = "ILCoreDiagnosisRoleToSnomed"
+* status = #active
+* experimental = false
+* date = "2026-05-28"
+* publisher = "Israel Core Team"
+* group[0].source = $il-core-diagnosis-role
+* group[0].target = $sct
+* group[0].element[0].code = #primary-diagnosis
+* group[0].element[=].display = "Primary diagnosis"
+* group[0].element[=].target.code = #8319008
+* group[0].element[=].target.display = "Principal diagnosis (contextual qualifier) (qualifier value)"
+* group[0].element[=].target.equivalence = #narrower
+* group[0].element[=].target.comment = "Although the original IL Core 'primary-diagnosis' code was intended to mean 'principal diagnosis,' its loose definition allowed for broader interpretations. Exercise caution when transitioning to the SNOMED CT code to ensure it aligns with how the deprecated code was actually used."
+* group[0].element[+].code = #secondary-diagnosis
+* group[0].element[=].display = "Secondary diagnosis"
+* group[0].element[=].target.code = #85097005
+* group[0].element[=].target.display = "Secondary diagnosis (contextual qualifier) (qualifier value)"
+* group[0].element[=].target.equivalence = #equivalent

--- a/ILCore/input/fsh/ValueSets/ValueSet-il-core-diagnosis-role.fsh
+++ b/ILCore/input/fsh/ValueSets/ValueSet-il-core-diagnosis-role.fsh
@@ -1,11 +1,13 @@
 ValueSet: VsILCoreDiagnosisRole
 Id: il-core-diagnosis-role
 Title: "IL Core Diagnosis Role"
-Description: "Diagnosis role value set combining HL7 diagnosis roles and IL Core additions for use across clinical contexts."
+Description: "Diagnosis role value set combining HL7 diagnosis roles and SNOMED CT diagnosis role qualifier values for use across clinical contexts."
 * ^url = $vs-il-core-diagnosis-role
 * ^status = #active
 * insert ConformanceMetadata
 * ^experimental = false
 
-* include codes from system $il-core-diagnosis-role
 * include codes from valueset $vs-diagnosis-role
+* $sct#8319008 "Principal diagnosis (contextual qualifier) (qualifier value)"
+* $sct#85097005 "Secondary diagnosis (contextual qualifier) (qualifier value)"
+* $sct#148006 "Preliminary diagnosis (contextual qualifier) (qualifier value)"

--- a/ILCore/input/fsh/codeSystems/CodeSystem-il-core-diagnosis-role.fsh
+++ b/ILCore/input/fsh/codeSystems/CodeSystem-il-core-diagnosis-role.fsh
@@ -1,13 +1,21 @@
 CodeSystem: ILCoreDiagnosisRole
 Id: il-core-diagnosis-role
 Title: "IL Core Diagnosis Role"
-Description: "Additional diagnosis role codes used for diagnosis role elements in clinical contexts such as encounters and episodes of care."
-* ^status = #active
+Description: "Deprecated diagnosis role codes formerly used for diagnosis role elements in clinical contexts such as encounters and episodes of care."
+* ^status = #retired
 * insert ConformanceMetadata
 * ^url = $il-core-diagnosis-role
 * ^content = #complete
 * ^caseSensitive = false
 * ^experimental = false
+* ^property[0].code = #status
+* ^property[=].uri = "http://hl7.org/fhir/concept-properties#status"
+* ^property[=].description = "A property that indicates the status of the concept. One of active, experimental, deprecated, retired"
+* ^property[=].type = #code
 
 * #primary-diagnosis "Primary diagnosis" "Primary diagnosis for the relevant clinical context (e.g., encounter or episode of care)."
+  * ^property.code = #status
+  * ^property.valueCode = #deprecated
 * #secondary-diagnosis "Secondary diagnosis" "Secondary diagnosis for the relevant clinical context (e.g., encounter or episode of care)."
+  * ^property.code = #status
+  * ^property.valueCode = #deprecated

--- a/ILCore/simplifier-docs/CodeSystem-il-core-diagnosis-role.doc.md
+++ b/ILCore/simplifier-docs/CodeSystem-il-core-diagnosis-role.doc.md
@@ -1,5 +1,5 @@
 # IL Core Diagnosis Role CodeSystem
-Additional diagnosis role codes used with diagnosis role elements in IL Core clinical contexts.
+Deprecated diagnosis role codes formerly used with diagnosis role elements in IL Core clinical contexts.
 
 ## Canonical
 [http://fhir.health.gov.il/cs/il-core-diagnosis-role](http://fhir.health.gov.il/cs/il-core-diagnosis-role)
@@ -8,8 +8,8 @@ Additional diagnosis role codes used with diagnosis role elements in IL Core cli
 - [IL Core Diagnosis Role ValueSet](./ValueSet-il-core-diagnosis-role.doc.md)
 
 ## Diagnosis roles
-This code system adds IL Core diagnosis roles (primary and secondary) used alongside HL7 diagnosis roles. It is intended for diagnosis role elements such as `Encounter.diagnosis.use`, `EpisodeOfCare.diagnosis.role`, and other compatible contexts.
+This code system is retired. Its local primary and secondary diagnosis concepts are deprecated and are no longer included in the IL Core Diagnosis Role ValueSet. Use the corresponding SNOMED CT diagnosis role qualifier values instead. Originally it was intended for diagnosis role elements such as `Encounter.diagnosis.use`, `EpisodeOfCare.diagnosis.role`, and other compatible contexts.
 
 ## Codes
-- `primary-diagnosis` Primary diagnosis for the relevant clinical context.
-- `secondary-diagnosis` Secondary diagnosis for the relevant clinical context.
+- `primary-diagnosis` Primary diagnosis for the relevant clinical context. Deprecated; map to SNOMED CT `8319008` Principal diagnosis (contextual qualifier) (qualifier value).
+- `secondary-diagnosis` Secondary diagnosis for the relevant clinical context. Deprecated; map to SNOMED CT `85097005` Secondary diagnosis (contextual qualifier) (qualifier value).

--- a/ILCore/simplifier-docs/ValueSet-il-core-diagnosis-role.doc.md
+++ b/ILCore/simplifier-docs/ValueSet-il-core-diagnosis-role.doc.md
@@ -1,5 +1,5 @@
 # IL Core Diagnosis Role ValueSet
-Diagnosis role value set that combines HL7 diagnosis roles with IL Core additions.
+Diagnosis role value set that combines HL7 diagnosis roles with SNOMED CT diagnosis role qualifier values.
 
 ## Canonical
 [http://fhir.health.gov.il/ValueSet/il-core-diagnosis-role](http://fhir.health.gov.il/ValueSet/il-core-diagnosis-role)
@@ -9,7 +9,8 @@ Diagnosis role value set that combines HL7 diagnosis roles with IL Core addition
 
 ## Content
 - All codes from [http://terminology.hl7.org/ValueSet/diagnosis-role](http://terminology.hl7.org/ValueSet/diagnosis-role).
-- All codes from [http://fhir.health.gov.il/cs/il-core-diagnosis-role](http://fhir.health.gov.il/cs/il-core-diagnosis-role).
+- SNOMED CT `8319008` Principal diagnosis (contextual qualifier) (qualifier value).
+- SNOMED CT `85097005` Secondary diagnosis (contextual qualifier) (qualifier value).
 
 ## Usage
 Use this value set for diagnosis role elements such as `Encounter.diagnosis.use` and `EpisodeOfCare.diagnosis.role` (extensible binding in IL Core profiles).


### PR DESCRIPTION
Retire the local ILCoreDiagnosisRole CodeSystem and mark its primary-diagnosis and secondary-diagnosis concepts as deprecated using the standard concept status property.

Remove the local IL Core diagnosis-role CodeSystem from VsILCoreDiagnosisRole and replace it with explicit SNOMED CT qualifier concepts for principal, secondary, and preliminary diagnosis while retaining the HL7 diagnosis-role ValueSet include.

Add ILCoreDiagnosisRoleToSnomed to map deprecated local diagnosis role codes to their SNOMED CT replacements. The primary-diagnosis mapping is marked narrower and includes a caution that the local code may have been used with a wider interpretation than principal diagnosis.

Update the Simplifier diagnosis-role documentation to describe the retired local CodeSystem and the SNOMED CT ValueSet content.